### PR TITLE
Add filter reset on Shave History page load

### DIFF
--- a/src/actions/shaves.js
+++ b/src/actions/shaves.js
@@ -53,6 +53,11 @@ export const setShaveFilterEnd = date => ({
   date,
 });
 
+export const RESET_SHAVE_FILTER = 'RESET_SHAVE_FILTER';
+export const resetShaveFilter = () => ({
+  type: RESET_SHAVE_FILTER,
+});
+
 export const getShaves = () => (dispatch, getState) => {
   dispatch(getShavesRequest());
   const { authToken } = getState().auth;

--- a/src/components/Shave-history.jsx
+++ b/src/components/Shave-history.jsx
@@ -8,6 +8,7 @@ import {
   getShaves,
   setShaveFilterStart,
   setShaveFilterEnd,
+  resetShaveFilter,
 } from '../actions/shaves';
 import ShaveHistoryItems from './Shave-history-items';
 
@@ -15,6 +16,7 @@ class ShaveHistory extends React.Component {
   componentWillMount() {
     const { dispatch } = this.props;
     dispatch(getShaves());
+    dispatch(resetShaveFilter());
   }
 
 

--- a/src/reducers/shaves.js
+++ b/src/reducers/shaves.js
@@ -8,6 +8,7 @@ import {
   ADD_SHAVE_ERROR,
   SET_SHAVE_FILTER_START,
   SET_SHAVE_FILTER_END,
+  RESET_SHAVE_FILTER,
 } from '../actions/shaves';
 
 const initialState = {
@@ -83,6 +84,12 @@ export default function shaveReducer(state = initialState, action) {
         endFilter: action.date,
       };
 
+    case RESET_SHAVE_FILTER:
+      return {
+        ...state,
+        startFilter: null,
+        endFilter: null,
+      };
 
     default:
       return state;


### PR DESCRIPTION
The time filters on shave history persisted when navigating away from and back to the shave history page (though the filter inputs would indicate nothing was chosen). This now resets the filters in the store when navigating to the page.