### PR TITLE
Add Share checkbox on new shave form, display Share tag on view shaves

### DIFF
--- a/src/components/Shave-form.jsx
+++ b/src/components/Shave-form.jsx
@@ -16,7 +16,6 @@ class ShaveForm extends React.Component {
   onSubmit(e) {
     e.preventDefault();
     const today = moment().format('YYYY-M-D');
-
     const data = {
       razorId: e.target.razor.value ? e.target.razor.value : null,
       bladeId: e.target.blade.value ? e.target.blade.value : null,
@@ -24,6 +23,7 @@ class ShaveForm extends React.Component {
       latherId: e.target.lather.value ? e.target.lather.value : null,
       aftershaveId: e.target.aftershave.value ? e.target.aftershave.value : null,
       additionalCareId: e.target.additionalcare.value ? e.target.additionalcare.value : null,
+      share: e.target.share.checked,
       rating: e.target.rating.value,
       date: e.target.date.value ? e.target.date.value : today,
     };
@@ -115,6 +115,9 @@ class ShaveForm extends React.Component {
           <option value="" disabled>Additional Care</option>
           {productsObj ? productsObj.additionalcare : null}
         </select>
+
+        <label>Share with community?</label>
+        <input type="checkbox" name="share" value="share" />
 
         <fieldset className="rating">
           <legend>Rating:</legend>

--- a/src/components/Shave-history-items.jsx
+++ b/src/components/Shave-history-items.jsx
@@ -11,7 +11,14 @@ class ShaveHistoryItems extends React.Component {
   }
 
   render() {
-    const { canDelete, showUsername, shaveHistory, startFilter, endFilter } = this.props;
+    const {
+      canDelete,
+      showUsername,
+      showShare,
+      shaveHistory,
+      startFilter,
+      endFilter,
+    } = this.props;
     if (!shaveHistory || !shaveHistory.length > 0) {
       return <div>No history!</div>;
     }
@@ -28,16 +35,9 @@ class ShaveHistoryItems extends React.Component {
       const endFilterComp = endFilter ? new Date(endFilter) : null;
 
       if (startFilterComp && itemDateComp.getTime() < startFilterComp.getTime()) {
-        // console.log('itemDate is before startFilter');
-        // console.log('comp:', itemDateComp.getTime());
-        // console.log('filt:', startFilterComp.getTime());
         continue;
       }
-
       if (endFilterComp && endFilterComp.getTime() < itemDateComp.getTime()) {
-        // console.log('itemDate is after endFilter');
-        // console.log('comp:', itemDateComp);
-        // console.log('filt:', endFilterComp);
         continue;
       }
 
@@ -61,6 +61,13 @@ class ShaveHistoryItems extends React.Component {
         ? [
           <span className="shave-list-item-products--label" key="usernameLabel">User: </span>,
           <span key="usernameVal">{sortedShaveHist[i].username}</span>,
+        ]
+        : '';
+
+      const share = showShare
+        ? [
+          <span className="shave-list-item-products--label" key="shareLabel">Shared: </span>,
+          <span key="shareVal">{sortedShaveHist[i].share ? 'Yes' : 'No'}</span>,
         ]
         : '';
 
@@ -90,6 +97,8 @@ class ShaveHistoryItems extends React.Component {
             <span className="shave-list-item-products--label">Additional Care: </span>
             <span>{nicknames.additionalCare}</span>
 
+            {share}
+
           </div>
           {deleteButton}
         </div>,
@@ -103,15 +112,21 @@ class ShaveHistoryItems extends React.Component {
 }
 
 ShaveHistoryItems.propTypes = {
+  startFilter: PropTypes.string,
+  endFilter: PropTypes.string, // filters are YYYY-MM-DD dates stored as strings
   canDelete: PropTypes.bool,
   showUsername: PropTypes.bool,
+  showShare: PropTypes.bool,
   shaveHistory: PropTypes.arrayOf(Object),
   dispatch: PropTypes.func.isRequired,
 };
 
 ShaveHistoryItems.defaultProps = {
+  startFilter: null,
+  endFilter: null,
   canDelete: false,
   showUsername: false,
+  showShare: false,
   shaveHistory: [],
 };
 

--- a/src/components/Shave-history.jsx
+++ b/src/components/Shave-history.jsx
@@ -24,7 +24,7 @@ class ShaveHistory extends React.Component {
     const { dispatch, isLoading, error } = this.props;
     const shaveContent = isLoading
       ? (<p>Loading...</p>)
-      : (<ShaveHistoryItems canDelete />);
+      : (<ShaveHistoryItems canDelete showShare />);
 
     return (
       <div className="shave-history">


### PR DESCRIPTION
When creating a new shave, users can now specify to share that shave to the community. When viewing their own shave history, an additional field indicates which shaves are shared to the community.

Requires update from server-side.