### PR TITLE
Set default values when clearing commShave date filters

### DIFF
--- a/src/components/Community-shave-history.jsx
+++ b/src/components/Community-shave-history.jsx
@@ -40,7 +40,8 @@ class ShaveHistory extends React.Component {
             type="date"
             value={startFilter}
             onChange={(e) => {
-              dispatch(setShaveFiltersGetCommunityShaves(e.target.value, endFilter));
+              const newStart = e.target.value || moment().subtract('months', 1).format('YYYY-MM-DD')
+              dispatch(setShaveFiltersGetCommunityShaves(newStart, endFilter));
             }}
           />
 
@@ -50,7 +51,8 @@ class ShaveHistory extends React.Component {
             type="date"
             value={endFilter}
             onChange={(e) => {
-              dispatch(setShaveFiltersGetCommunityShaves(startFilter, e.target.value));
+              const newEnd = e.target.value || moment().format('YYYY-MM-DD');
+              dispatch(setShaveFiltersGetCommunityShaves(startFilter, newEnd));
             }}
           />
         </div>


### PR DESCRIPTION
The start and end date filters on the Community Shave page default to one month ago and today, respectively. Clearing either of these filter dates results in a database error, since a sent value is undefined. Clearing either of these filters now resets the relevant filter to its default value instead of clearing it entirely.