### PR TITLE
Add overflow rule to modals

### DIFF
--- a/src/components/styles/shave-history.css
+++ b/src/components/styles/shave-history.css
@@ -67,7 +67,7 @@
 
 .Modal {
   position: fixed;
-  overflow: scroll;
+  overflow: auto;
   top: 120px;
   left: 150px;
   right: 150px;

--- a/src/components/styles/shave-history.css
+++ b/src/components/styles/shave-history.css
@@ -67,12 +67,13 @@
 
 .Modal {
   position: fixed;
-  top: 150px;
+  overflow: scroll;
+  top: 120px;
   left: 150px;
   right: 150px;
   bottom: 150px;
   background-color: #fffcf2;
-  height: 520px;
+  
   }
 
 .Overlay {


### PR DESCRIPTION
This keeps the modal from going offscreen when an image is uploaded. Also fixes the Rating Box overflowing off the edge of the modal.